### PR TITLE
Switch to sep==1.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ reproject==0.14.0
 scikit-learn==1.5.2
 scikit-image==0.24.0
 scipy==1.14.1
-sep-pjw==1.3.6
+sep==1.4.1
 setuptools==75.1.0
 sqlalchemy==2.0.36
 sunkit_image==0.6.0


### PR DESCRIPTION
sep has changed source so we should follow suit to get rid of the warning that always happens with sep. 