### PR TITLE
Update required versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pydantic==2.11.7
 pylibjpeg[libjpeg, openjpeg]==2.0.1
 python-dateutil==2.9.0
 quadprog==0.1.12
-remove_starfield==0.0.4
+remove_starfield==0.1
 reproject==0.14.0
 scikit-learn==1.5.2
 scikit-image==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sep==1.4.1
 setuptools==78.1.1
 sqlalchemy==2.0.36
 sunkit_image==0.6.0
-sunpy[all]==6.0.3
+sunpy[all]==6.1
 toml==0.10.2
 tqdm==4.66.6
 xlrd==2.0.1


### PR DESCRIPTION
We got a report that SunPy needs to be >= 6.1. This fixes that and then I'll check for the rest of the dependencies. 